### PR TITLE
Feature/paging

### DIFF
--- a/api_document/aboutComment.md
+++ b/api_document/aboutComment.md
@@ -111,15 +111,15 @@ Create a comment to a single post.
 
 
 ---
-**Show all comments of a single post**
+**Show all comments of a single post with infinity scroll**
 ----
 게시물 하나의 모든 댓글 보기. 댓글 객체 정보 + user의 nickname, portrait 정보 반환함. data 안 user 속성으로 접근할 수 있음.
-Show all comments of a single post. Return full data of the comments and user's nickname, portrait.
+Show all comments of a single post with infinity scroll. Return full data of the comments and user's email, nickname, portrait.
 
 * **URL**
 
-  /all/:board_id
-  >*변경됨: `/comment/selectall/:board_id` -> `/comments/all/:board_id`*
+  /all/scroll/:board_id/:lastid
+  >*변경됨: `/comment/selectall/:board_id` -> `/comments/all/scroll/:board_id/:lastid`*
   
 
 * **Method:**
@@ -129,6 +129,8 @@ Show all comments of a single post. Return full data of the comments and user's 
 *  **URL Params**
 
    * `board_id=[integer]` 게시물 번호(ID)
+   * `lastid=[integer]` 마지막 (가장 아래의) 댓글 번호(ID)
+        > 댓글은 최초 작성된 댓글이 가장 위에 오는 오름차순 정렬 -> lastid 보다 큰 것들을 불러옴
 
 * **Data Params**
 
@@ -196,6 +198,126 @@ Show all comments of a single post. Return full data of the comments and user's 
                 }
             ],
             "message": "해당 게시물의 전체 댓글 조회 성공"
+        }
+        ```
+
+      * **Code:** 200
+        **Content:** 조회 요청했으나 댓글이 하나도 없을 때<br/>
+
+        * **Sample request JSON data:**
+        ```json
+            {
+                "success": true,
+                "data": "",
+                "message": "해당 게시물에 댓글이 없습니다."
+            }
+        ```
+
+        **Content:** 조회 요청했으나 더 이상 불러올 댓글이 하나도 없을 때<br/>
+
+        * **Sample request JSON data:**
+        ```json
+            {
+                "success": true,
+                "data": "",
+                "message": "더 이상 불러올 댓글이 없습니다."
+            }
+        ```
+    </div>
+    </details>
+
+    <details>
+    <summary>Error Response</summary>
+    <div markdown="1">
+
+    * **Code:** 존재하지 않는 게시물의 댓글들을 조회하려고 할 때<br/>
+        **Content:** 
+        ```json
+            {
+                "success": false,
+                "data": "",
+                "message": "존재하지 않는 게시물의 댓글은 조회할 수 없습니다."
+            }
+        ```
+
+    </div>
+    </details>
+
+---
+**Show all comments of a single post with pages**
+----
+페이지로 게시물 하나의 모든 댓글 보기. 총 페이지 수(result.count) + 댓글 객체 정보(result.data) + user의 email, nickname, portrait 정보 반환함. data 안 user 속성으로 접근할 수 있음.
+Show all comments of a single post with pages. Return the number of total pages, full data of the comments and user's email, nickname, portrait.
+
+* **URL**
+
+  /all/page/:board_id/:page/:countPerPage
+  >*변경됨: `/comment/selectall/:board_id` -> `/comments/all/page/:board_id/:page/:countPerPage`*
+  
+
+* **Method:**
+
+  `GET`
+  
+*  **URL Params**
+
+   * `board_id=[integer]` 게시물 번호(ID)
+   * `page=[integer]` 페이지 번호
+        > 페이지 0 이하면 1페이지로 간주하고 페이지 범위 초과 시 가장 마지막 페이지로 간주함
+   * `countPerPage=[integer]` 한 페이지 당 보여 줄 객체 수
+
+* **Data Params**
+
+    None
+
+* **Response:**
+
+    <details>
+    <summary>Success Response</summary>
+    <div markdown="1">
+
+    * **Code:** 200
+        **Content:** 해당 게시물의 모든 댓글 및 총 페이지 수(count) 불러오기<br/>
+
+        * **Sample response JSON data:**
+
+        ```json
+        {
+            "success": true,
+            "data": [
+                {
+                    "id": 10,
+                    "comment_content": "test_by2",
+                    "confirm": false,
+                    "createdAt": "2020-02-05T09:18:41.000Z",
+                    "updatedAt": "2020-02-05T09:18:41.000Z",
+                    "deletedAt": null,
+                    "fk_user_uid": "$2b$12$IeUzBAMlvYWhLeKUM0LgLeyeCQa2c/1mbyCWiI89e8DHxwpaU78Qa",
+                    "fk_board_id": 15,
+                    "user": {
+                        "email": "1",
+                        "nickname": "aa",
+                        "portrait": ""
+                    }
+                },
+                {
+                    "id": 11,
+                    "comment_content": "test_by2",
+                    "confirm": false,
+                    "createdAt": "2020-02-05T09:18:42.000Z",
+                    "updatedAt": "2020-02-05T09:18:42.000Z",
+                    "deletedAt": null,
+                    "fk_user_uid": "$2b$12$IeUzBAMlvYWhLeKUM0LgLeyeCQa2c/1mbyCWiI89e8DHxwpaU78Qa",
+                    "fk_board_id": 15,
+                    "user": {
+                        "email": "1",
+                        "nickname": "aa",
+                        "portrait": ""
+                    }
+                }
+            ],
+            "message": "해당 게시물의 전체 댓글 조회 성공",
+            "count": 5
         }
         ```
 

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -15,12 +15,16 @@ let result = { // response form
  * - parameter user_id : 로그인 한 회원 uuid
  * - parameter friend_id : 친구 추가할 회원 uuid
  */
-router.get('/all/:board_id', clientIp, isLoggedIn, async(req, res, next)=>{
+router.get('/all/:board_id/:page/:countPerPage', clientIp, isLoggedIn, async(req, res, next)=>{
     const user_email = req.user.email;
-    const board_id = parseInt(req.params.board_id);
+    const board_id = req.params.board_id;
+    const page = parseInt(req.params.page)
+    let countPerPage = 10;
+    if(parseInt(req.params.countPerPage)!=0) countPerPage = parseInt(req.params.countPerPage)
+    let startNum = 1 + countPerPage*(page-1);
 
     winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] 게시물의 전체 댓글 목록 Request`);
-    winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] board_id : ${board_id}`);
+    winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] board_id : ${board_id}, page : ${page}, countPerPage : ${countPerPage}`);
 
     result.data = '';
     try{
@@ -37,15 +41,13 @@ router.get('/all/:board_id', clientIp, isLoggedIn, async(req, res, next)=>{
                 model: User,
                 attributes: ['email', 'nickname', 'portrait'],
             }],
-            paranoid: false // 삭제된 데이터도 반환
+            offset: startNum,
+            limit: countPerPage,
         }).then(comments=>{
             if(comments){
                 if(comments[0]){
                     result.message = "해당 게시물의 전체 댓글 조회 성공";
                     result.data = comments;
-                }else{
-                    result.message = "해당 게시물에 댓글이 없습니다.";
-                    result.data = '';
                 }
                 result.success = true;
                 winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] ${result.message}`);

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -2,7 +2,7 @@ const winston = require('../config/winston');
 const { clientIp, isLoggedIn, isNotLoggedIn } = require('./middlewares');
 
 const express = require('express');
-const { User, Feedback, Board, Comment } = require('../models');
+const { User, Feedback, Board, Comment, Sequelize: { Op } } = require('../models');
 const router = express.Router();
 
 let result = { // response form
@@ -15,13 +15,82 @@ let result = { // response form
  * - parameter user_id : 로그인 한 회원 uuid
  * - parameter friend_id : 친구 추가할 회원 uuid
  */
-router.get('/all/:board_id/:page/:countPerPage', clientIp, isLoggedIn, async(req, res, next)=>{
+router.get('/all/scroll/:board_id/:lastid', clientIp, isLoggedIn, async(req, res, next)=>{
+    const user_email = req.user.email;
+    const board_id = parseInt(req.params.board_id);
+    let lastid = parseInt(req.params.lastid);
+
+    // if (lastid === 0) {
+    //     lastid = 9999;
+    // }
+    // 댓글은 최초 작성된 댓글이 가장 위에 오는 오름차순 정렬 -> lastid 보다 큰 것들을 불러옴
+
+    winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] 게시물의 전체 댓글 목록 Request`);
+    winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] board_id : ${board_id}`);
+
+    result.data = '';
+    try{
+        const exBoard = await Board.findOne({where:{id: board_id}})
+        if(!exBoard){
+            result.success = false;
+            result.message = "존재하지 않는 게시물의 댓글은 조회할 수 없습니다.";
+            winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] ${result.message}`);
+            return res.status(200).json(result);
+        }
+        await Comment.findAll({
+            where: { id: { [Op.gt]: lastid } , fk_board_id: board_id},
+            order: [['id']], 
+            limit: 10,
+            include: [{ // 댓글 작성자의 nickname, portrait 정보 가져오기
+                model: User,
+                attributes: ['email', 'nickname', 'portrait'],
+            }],
+        }).then(comments=>{
+            if(comments){
+                if(comments[0]){
+                    result.message = "해당 게시물의 전체 댓글 조회 성공";
+                    result.data = comments;
+                }else{
+                    result.message = "더 이상 불러올 댓글이 없습니다."
+                    if(lastid===0){
+                        result.message = "해당 게시물에 댓글이 없습니다.";
+                    }
+                    result.data = '';
+                }
+                result.success = true;
+                winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] ${result.message}`);
+                return res.status(200).json(result);
+            }else{
+                result.success = false;
+                result.message = "해당 게시물의 전체 댓글 조회 실패";
+                winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] ${result.message}`);
+                return res.status(200).json(result);
+            }
+        });
+    }catch(e){
+        winston.log('error', `[COMMENT][${req.clientIp}|${req.user.email}] 게시물의 전체 댓글 목록 Exception`);
+        
+        const result = new Object();
+        result.success = false;
+        result.data = 'NONE';
+        result.message = 'INTERNAL SERVER ERROR';
+        winston.log('error', `[COMMENT][${req.clientIp}|${req.body.email}] ${result.message}`);
+        res.status(500).send(result);
+        return next(e);
+    }
+});
+
+/* get all comment = 전체 댓글보기가 곧 해당 게시물 보기와 같음.
+ * - parameter user_id : 로그인 한 회원 uuid
+ * - parameter friend_id : 친구 추가할 회원 uuid
+ */
+router.get('/all/page/:board_id/:page/:countPerPage', clientIp, isLoggedIn, async(req, res, next)=>{
     const user_email = req.user.email;
     const board_id = req.params.board_id;
-    const page = parseInt(req.params.page)
+    let page = parseInt(req.params.page)
     let countPerPage = 10;
     if(parseInt(req.params.countPerPage)!=0) countPerPage = parseInt(req.params.countPerPage)
-    let startNum = 1 + countPerPage*(page-1);
+    
 
     winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] 게시물의 전체 댓글 목록 Request`);
     winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] board_id : ${board_id}, page : ${page}, countPerPage : ${countPerPage}`);
@@ -35,6 +104,25 @@ router.get('/all/:board_id/:page/:countPerPage', clientIp, isLoggedIn, async(req
             winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] ${result.message}`);
             return res.status(200).json(result);
         }
+        await Comment.count({
+            where:{fk_board_id: board_id},
+        }).then(count=>{
+            if(count == 0){
+                result.success = true;
+                result.message = "해당 게시물에 댓글이 없습니다.";
+                result.data = '';
+                winston.log('info', `[COMMENT][${req.clientIp}|${user_email}] ${result.message}`);
+                return res.status(200).json(result);
+            }
+            // 총 페이지 수 반환
+            result.count = Math.ceil(count/countPerPage);
+        })
+        // 페이지 0 이하면 1페이지로 간주
+        if(page<1) page = 1;
+        // 페이지 범위 초과 시 가장 마지막 페이지로 간주
+        if(page>result.count) page = result.count;
+        let startNum = 1 + countPerPage*(page-1);
+
         await Comment.findAll({
             where:{fk_board_id: board_id},
             include: [{ // 댓글 작성자의 nickname, portrait 정보 가져오기


### PR DESCRIPTION
한 게시물의 전체 댓글 조회 페이징 & 인피니티 스크롤 구현
---
기존에 무조건 전체 댓글 데이터를 불러오던 라우터를 페이징용, 스크롤용 두 개로 나누었습니다. 페이지는 단순 개수로 가져오고 스크롤은 id를 사용하기 때문입니다. 페이징용의 경우 기존 result.data 외에 result.count 변수에 **총 페이지 수**를 반환합니다.

### 1. 페이징 라우터: (get) comments/all/page/:board_id/:page/:countPerPage
- page(페이지번호), countPerPage(한 페이지 당 보여줄 객체 수) 변수 추가됨
- 1 미만 페이지는 1페이지로, 마지막 페이지 초과하는 것은 마지막 페이지로 간주함
- 총 페이지 수(result.count) 값 반환 추가

### 2. 인피니티 스크롤 라우터: (get) comments/all/scroll/:board_id/:lastid
- lastid(마지막 댓글 번호) 변수 추가됨
- 댓글은 오래된 것이 위로 오는 오름차순 정렬->lastid 보다 id값이 큰 것들을 불러옴
- 처음부터 댓글이 없는 경우 / 더 이상 불러올 댓글이 없는 경우 메시지 다르게 처리함